### PR TITLE
Fix non chainable multi line relations

### DIFF
--- a/lib/montage_rails/relation.rb
+++ b/lib/montage_rails/relation.rb
@@ -66,11 +66,19 @@ module MontageRails
       to_a.inspect
     end
 
+    # Checks to see if the relation is loadable
+    # If we are in test or dev environment, this is always true, otherwise
+    # it falls back to checking the loaded? instance variable
+    #
+    def loadable?
+      %w(test development).include?(Rails.env) || !loaded?
+    end
+
     # Returns the set of records if they have already been fetched, otherwise
     # gets the records and returns them
     #
     def to_a
-      return @records if loaded?
+      return @records unless loadable?
 
       @response = cache.get_or_set_query(klass, query) do
         connection.documents(klass.table_name, query)

--- a/lib/montage_rails/version.rb
+++ b/lib/montage_rails/version.rb
@@ -1,3 +1,3 @@
 module MontageRails
-  VERSION = "0.7"
+  VERSION = "0.7.1"
 end

--- a/test/montage_rails/relation_test.rb
+++ b/test/montage_rails/relation_test.rb
@@ -99,6 +99,46 @@ class MontageRails::RelationTest < Minitest::Test
     end
   end
 
+  context "#loadable?" do
+    setup do
+      @relation = MontageRails::Relation.new(Movie)
+    end
+
+    should "be loadable in the test enviroment" do
+      Rails.stubs(:env).returns("test")
+      assert @relation.loadable?
+    end
+
+    should "be loadable in the development environment" do
+      Rails.stubs(:env).returns("development")
+      assert @relation.loadable?
+    end
+
+    should "be loadable in the production env when not loaded" do
+      Rails.stubs(:env).returns("production")
+      @relation.stubs(:loaded?).returns(false)
+      assert @relation.loadable?
+    end
+
+    should "not be loadable in the production env when loaded" do
+      Rails.stubs(:env).returns("production")
+      @relation.stubs(:loaded?).returns(true)
+      refute @relation.loadable?
+    end
+
+    should "be loadable in the test env when loaded" do
+      Rails.stubs(:env).returns("test")
+      @relation.stubs(:loaded?).returns(true)
+      assert @relation.loadable?
+    end
+
+    should "be loadable in the dev env when loaded" do
+      Rails.stubs(:env).returns("development")
+      @relation.stubs(:loaded?).returns(true)
+      assert @relation.loadable?
+    end
+  end
+
   context "#to_a" do
     should "return the record set without a query if the records have already been fetched" do
       @relation = MontageRails::Relation.new(Movie)


### PR DESCRIPTION
This fixes an issue where relations in dev and test environments were
not chainable across multiple lines. In dev and test environments, after
every line of code executed, `.to_a` is called on relations so that you
can see their output. This was causing the `.loaded?` method to return
true, and any extra queries not being run. This fixes that.

Fixes #19