### PR TITLE
Fix type coercion error

### DIFF
--- a/lib/montage_rails/base/column.rb
+++ b/lib/montage_rails/base/column.rb
@@ -29,17 +29,18 @@ module MontageRails
       # Returns true or false
       #
       def is_i?(value)
-        /\A\d+\z/ =~ value
+        /\A\d+\z/ =~ value.to_s
       end
 
       # Determines if the string value passed in is a float
       # Returns true or false
       #
       def is_f?(value)
-        /\A\d+\.\d+\z/ =~ value
+        /\A\d+\.\d+\z/ =~ value.to_s
       end
 
       def coerce(value)
+        return nil unless value
         return value if value.is_a?(TYPE_MAP[type])
 
         if is_i?(value)

--- a/lib/montage_rails/version.rb
+++ b/lib/montage_rails/version.rb
@@ -1,3 +1,3 @@
 module MontageRails
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end

--- a/test/montage_rails/base/column_test.rb
+++ b/test/montage_rails/base/column_test.rb
@@ -55,5 +55,32 @@ class MontageRails::Base::ColumnTest < Minitest::Test
       column = MontageRails::Base::Column.new("foo", "float")
       assert_equal "foo", column.coerce("foo")
     end
+
+    should "coerce a float to a float when the float is not a string" do
+      column = MontageRails::Base::Column.new("foo", "numeric")
+      assert_equal 60.0, column.coerce(60.000000)
+    end
+  end
+
+  context "is_i?" do
+    setup do
+      @column = MontageRails::Base::Column.new("foo", "numeric")
+    end
+
+    should "properly handle Fixnum and Floats" do
+      assert @column.is_i?(60)
+      refute @column.is_i?(60.45)
+    end
+  end
+
+  context "is_f?" do
+    setup do
+      @column = MontageRails::Base::Column.new("foo", "numeric")
+    end
+
+    should "properly handle Fixnum and floats" do
+      assert @column.is_f?(60.45)
+      refute @column.is_f?(60)
+    end
   end
 end


### PR DESCRIPTION
This fixes the issue where a Fixnum or Float being passed into the
`.to_i?` or `.to_f?` methods in the column class would raise a type
error. Now all values are explicilty cast to a string.

Fixes #21
